### PR TITLE
Correcting package leiningen-clojure to leiningen in installation com…

### DIFF
--- a/project-ideas/detailed-specs/cypress-testing.md
+++ b/project-ideas/detailed-specs/cypress-testing.md
@@ -59,7 +59,7 @@ Type the following commands to install dependencies:
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk leiningen-clojure nodejs npm python3-pip git
+sudo apt install openjdk-11-jdk leiningen nodejs npm python3-pip git
 ```
 
 Follow **steps 1 and 2** from:  


### PR DESCRIPTION
…mand for Linux or WSL

Package installation for Linux or WSL  includes ``` leiningen-clojure ``` which is non existent instead of ``` leiningen ``` which is the actual required package